### PR TITLE
Update demo page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Svelte Color Picker [\[Demo Page\]](https://qintarp.github.io/svelte-color-picker)
+# Svelte Color Picker [\[Demo Page\]](https://efeskucuk.github.io/svelte-color-picker/)
  [![svelte-v3](https://img.shields.io/badge/svelte-v3-blueviolet.svg)](https://svelte.dev)
 ## Installation
 


### PR DESCRIPTION
Current link leads to 404, seems to be incorrectly linking to https://qintarp.github.io/svelte-color-picker, so I've changed it.